### PR TITLE
Converted broken image to text linking to video

### DIFF
--- a/interceptors/custom_events.md
+++ b/interceptors/custom_events.md
@@ -1,8 +1,5 @@
 # Custom Events
 
-Apart from all the announced events by the framework, you can also register your own custom events.
+In addition to all the events announced by the framework, you can also register your own custom events.
 
-**Instructional Video**
-
-<a href="https://vimeo.com/17409335">![](video_customInterceptionPoints.png)</a>
-
+[Curt Gratz](https://vimeo.com/gratzc) shares a brief example and use case for ColdBox custom interception points in his video [ColdBox Custom Interception Points - How To](https://vimeo.com/17409335).


### PR DESCRIPTION
I tried to dig up the image referenced in the markdown, but I never managed to locate it. Instead, I replaced the image (presumably a thumbnail of the video) with some text describing what the video is.